### PR TITLE
update main and devel badges + standard push/pull workflow triggers

### DIFF
--- a/.github/workflows/vagrantup.yml
+++ b/.github/workflows/vagrantup.yml
@@ -1,20 +1,20 @@
 name: vagrant-up
 
-on:
-  push:
-    branches: ["devel"]
-  pull_request:
-    branches: ["devel"]
-
-  pull_request_target:
-    branches:
-      - 'devel'
-      - 'main'
-    paths:
-      - '**.yml'
-      - '**.sh'
-      - '**.j2'
-      - '**.cfg'
+# Controls when the action will run.
+# Triggers the workflow on push or pull request
+# events but only for the devel branch
+on: # yamllint disable-line rule:truthy
+    pull_request_target:
+        types: [opened, reopened, synchronize]
+        branches:
+            - devel
+            - main
+        paths:
+            - '**.yml'
+            - '**.sh'
+            - '**.j2'
+            - '**.ps1'
+            - '**.cfg'
 
 jobs:
   vagrant-up:

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@
 [![Twitter URL](https://img.shields.io/twitter/url/https/twitter.com/AnsibleLockdown.svg?style=social&label=Follow%20%40AnsibleLockdown)](https://twitter.com/AnsibleLockdown)
 
 ![Discord Badge](https://img.shields.io/discord/925818806838919229?logo=discord)
-![Devel Build Status](https://img.shields.io/github/actions/workflow/status/ansible-lockdown/POSTGRES-12-CIS/vagrantup.yml?branch=devel&style=flat)
+
+![Devel Build Status](https://img.shields.io/github/actions/workflow/status/ansible-lockdown/POSTGRES-12-CIS/vagrantup.yml?label=Devel%20Build%20Status)
 ![Devel Commits](https://img.shields.io/github/commit-activity/m/ansible-lockdown/POSTGRES-12-CIS/devel?color=dark%20green&label=Devel%20Branch%20commits)
 
 ![Release Branch](https://img.shields.io/badge/Release%20Branch-Main-brightgreen)
-![Main Build Status](https://img.shields.io/github/actions/workflow/status/ansible-lockdown/POSTGRES-12-CIS/vagrantup.yml?branch=main&style=flat)
+![Main Build Status](https://img.shields.io/github/actions/workflow/status/ansible-lockdown/POSTGRES-12-CIS/vagrantup.yml?label=Build%20Status)
 ![Main Release Date](https://img.shields.io/github/release-date/ansible-lockdown/POSTGRES-12-CIS?label=Release%20Date)
 ![Release Tag](https://img.shields.io/github/v/tag/ansible-lockdown/POSTGRES-12-CIS?label=Release%20Tag&&color=success)
 


### PR DESCRIPTION
Overall Review of Changes:
update badges and workflow

Issue Fixes:
main branch badge was not loading status. With an update, badge status loads the main branch status.

Enhancements:
readme now loads all badges for devel and main branches.

How has this been tested?:
Directly in GitHub via markdown.